### PR TITLE
Fix comment typos and extend timezone tests

### DIFF
--- a/ios/Sources/TruckeeTrashKit/Utilities/DateUtils.swift
+++ b/ios/Sources/TruckeeTrashKit/Utilities/DateUtils.swift
@@ -17,7 +17,7 @@ public extension Date {
         var daysToAdd: Int
         
         if adjustedCurrentWeekday == targetWeekday {
-            // If today is the target weekday, its today
+            // If today is the target weekday, it's today
             daysToAdd = 0
         } else if adjustedCurrentWeekday < targetWeekday {
             // Target is later this week

--- a/ios/Tests/TruckeeTrashKitTests/DateUtilsTests.swift
+++ b/ios/Tests/TruckeeTrashKitTests/DateUtilsTests.swift
@@ -62,8 +62,27 @@ final class DateUtilsTests: XCTestCase {
     
     func testTruckeeCalendar() throws {
         let calendar = Calendar.truckeeCalendar
-        
+
         XCTAssertEqual(calendar.timeZone.identifier, "America/Los_Angeles")
         XCTAssertEqual(calendar.identifier, .gregorian)
+    }
+
+    func testIsWeekdayWithCustomTimeZone() throws {
+        let utc = TimeZone(identifier: "UTC")!
+        let la = TimeZone(identifier: "America/Los_Angeles")!
+
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 6
+        components.day = 2
+        components.hour = 6 // 6 AM UTC on June 2, 2025
+
+        var utcCalendar = Calendar(identifier: .gregorian)
+        utcCalendar.timeZone = utc
+        let date = utcCalendar.date(from: components)!
+
+        XCTAssertTrue(date.isWeekday(in: utc))
+        XCTAssertFalse(date.isWeekday(in: la))
+        XCTAssertTrue(date.isWeekend(in: la))
     }
 }

--- a/lib/pickupData.ts
+++ b/lib/pickupData.ts
@@ -49,8 +49,8 @@ export const recyclingDates2026 = new Set([
   "2026-04-24",
 ]);
 
-// Based on the provided CSV, there are no Yard Waste dates listed for 2026
-// within the range of the CSV (which ends May 1, 2026).
+// Based on the provided CSV, only one Yard Waste date is listed for 2026
+// within the range of the CSV (May 1, 2026).
 export const yardWasteDates2026 = new Set<string>([
   "2026-05-01",
 ]);


### PR DESCRIPTION
## Summary
- fix a comment typo in DateUtils
- correct yard waste date comment
- add timezone-aware test for `isWeekday`/`isWeekend`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845ae82d390832babc1910069d974e3