### PR TITLE
Skip Vercel builds for iOS-only commits

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "bash -c 'if [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] && git diff --name-only \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" | grep -qv \"^ios/\"; then exit 1; else exit 0; fi'"
+}


### PR DESCRIPTION
## Summary
- configure Vercel to ignore deployments when only the `ios` folder changed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462e5eda08832bbf62a461813cdc52